### PR TITLE
rewrite of the psm02 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Homey version >= 1.1.0
 
 
 Changelog:  
+0.0.17
+* Fix PSM02: door/window and tamper were working incorrectly
+
 0.0.16
 * Add support PSP05 - Outdoor Motion Sensor
 * Add proper icons and images PAN04/PAN06/PAN11

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": {
         "en": "Philio"
     },
-    "version": "0.0.16",
+    "version": "0.0.17",
     "compatibility": ">=1.1.0",
     "description": {
         "en": "Philio Z-Wave devices for Homey"
@@ -354,6 +354,23 @@
                     "hint": {
                         "en": "Interval time for auto report the temperature. 30 minutes per tick and minimum time is 30 minutes, default tick is 12 (6 hours)"
                     }
+                },
+                {
+                  	"id": "tamper_cancellation",
+                  	"type": "number",
+                  	"label": {
+                    		"en": "Tamper Cancellation Time",
+                    		"nl": "Sabotage Annulerings Tijd"
+                  	},
+                  	"hint": {
+                    		"en": "How many seconds will the tamper alarm be activated.\nRange: 0 (don't cancel), 1 - 86400 seconds",
+                    		"nl": "Hoeveel seconden moet het tamper alarm geactiveerd blijven.\nBereik: 0 (niet annuleren), 1 - 86400 seconden"
+                  	},
+                  	"value": 120,
+                  	"attr": {
+                    		"min": 0,
+                    		"max": 86400
+                  	}
                 }
             ]
         },

--- a/drivers/PSM02/driver.js
+++ b/drivers/PSM02/driver.js
@@ -1,6 +1,7 @@
-"use strict";
-var path = require('path');
+'use strict';
+const path = require('path');
 const ZwaveDriver = require('homey-zwavedriver');
+const tamperCancellation = {};
 // Product Name:	Slim Multi-Sensor PSM02
 // Brand Name:	Philio
 // Product Line:	Philio Z-Wave Product
@@ -8,108 +9,127 @@ const ZwaveDriver = require('homey-zwavedriver');
 // Product Version:	1.0
 
 module.exports = new ZwaveDriver(path.basename(__dirname), {
-    capabilities: {
-        'alarm_motion': {
-            'command_class': 'COMMAND_CLASS_SENSOR_BINARY',
-            'command_report': 'SENSOR_BINARY_REPORT',
-            'command_report_parser': report => report['Sensor Value'] === 'detected an event'
-        },
-        'alarm_contact': {
-            'command_class': 'COMMAND_CLASS_SENSOR_BINARY',
-            'command_report': 'SENSOR_BINARY_REPORT',
-            'command_report_parser': report => report['Sensor State'] === 'Door/Window'
-
-        },
-        'alarm_tamper': {
-            'command_class': 'COMMAND_CLASS_SENSOR_BINARY',
-            'command_report': 'SENSOR_BINARY_REPORT',
-            'command_report_parser': report => report['Sensor State'] === 'alarm'
-        },
-        'measure_temperature': {
-            'command_class': 'COMMAND_CLASS_SENSOR_MULTILEVEL',
-            'command_get_parser': () => ({
-                    'Sensor Type': "Temperature (version 1)",
-                    'Properties1': {'Scale': 0}
-            }),
-            'command_report': 'SENSOR_MULTILEVEL_REPORT',
-            'command_report_parser': report => {
-				if (report['Sensor Type'] !== 'Temperature (version 1)') return null;
-
-				return report['Sensor Value (Parsed)'];
-			}
-        },
-        'measure_luminance': {
-            'command_class': 'COMMAND_CLASS_SENSOR_MULTILEVEL',
-            'command_get_parser': () => ({
-                    'Sensor Type': "Luminance (version 1)",
-                    'Properties1': {'Scale': 0}
-            }),
-            'command_report': 'SENSOR_MULTILEVEL_REPORT',
-            'command_report_parser': report => {
-				if (report['Sensor Type'] !== 'Luminance (version 1)') return null;
-
-				return report['Sensor Value (Parsed)'];
-			}
-        },
-        'measure_battery': {
-            'getOnWakeUp': true,
-            'command_class': 'COMMAND_CLASS_BATTERY',
-            'command_get': 'BATTERY_GET',
-            'command_report': 'BATTERY_REPORT',
-            'command_report_parser': report => {
-				if (report['Battery Level'] === "battery low warning") return 1;
-
-				if (report.hasOwnProperty('Battery Level (Raw)'))
-					return report['Battery Level (Raw)'][0];
-
+	capabilities: {
+		alarm_motion: {
+			command_class: 'COMMAND_CLASS_SENSOR_BINARY',
+			command_report: 'SENSOR_BINARY_REPORT',
+			command_report_parser: report => {
+				if (report && report['Sensor Type'] === 'Motion') return report['Sensor Value'] === 'detected an event';
+				return null;
+			},
+		},
+		alarm_contact: {
+			command_class: 'COMMAND_CLASS_SENSOR_BINARY',
+			command_report: 'SENSOR_BINARY_REPORT',
+			command_report_parser: report => {
+				if (report && report['Sensor Type'] === 'Door/Window') return report['Sensor Value'] === 'detected an event';
+				return null;
+			},
+		},
+		alarm_tamper: {
+			command_class: 'COMMAND_CLASS_SENSOR_BINARY',
+			command_report: 'SENSOR_BINARY_REPORT',
+			command_report_parser: (report, node) => {
+				if (report['Sensor Type'] === 'Tamper' && report['Sensor Value'] === 'detected an event') {
+					if (node) {
+						if (tamperCancellation.hasOwnProperty(node.device_data.token) && tamperCancellation[node.device_data.token]) {
+							clearTimeout(tamperCancellation[node.device_data.token]);
+							tamperCancellation[node.device_data.token] = null;
+						}
+						if (node.settings.hasOwnProperty('tamper_cancellation') && node.settings.tamper_cancellation > 0) {
+							if (!tamperCancellation.hasOwnProperty('node.device_data.token')) tamperCancellation[node.device_data.token];
+							tamperCancellation[node.device_data.token] = setTimeout(() => {
+								node.state.alarm_tamper = false;
+								module.exports.realtime(node.device_data, 'alarm_tamper', false);
+							}, node.settings.tamper_cancellation * 1000);
+						}
+					}
+					return true;
+				}
 				return null;
 			}
-        }
-    },
-    settings: {
-        "basic_set_level": {
-            "index": 2,
-            "size": 1
-        },
-        "pir_sensitivity": {
-            "index": 3,
-            "size": 1
-        },
-        "light_threshold": {
-            "index": 4,
-            "size": 1
-        },
-        "operation_mode": {
-            "index": 5,
-            "size": 1,
-        },
-        "multi_sensor_function_switch": {
-            "index": 6,
-            "size": 1,
-        },
-        "pir_re_detect_interval_time": {
-            "index": 8,
-            "size": 1
-        },
-        "turn_off_light_time": {
-            "index": 9,
-            "size": 1
-        },
-        "auto_report_battery_time": {
-            "index": 10,
-            "size": 1
-        },
-        "auto_report_door_window_state_time": {
-            "index": 11,
-            "size": 1
-        },
-        "auto_report_illumination_time": {
-            "index": 12,
-            "size": 1
-        },
-        "auto_report_temperature_time": {
-            "index": 13,
-            "size": 1
-        }
-    }
-})
+		},
+		measure_temperature: {
+			command_class: 'COMMAND_CLASS_SENSOR_MULTILEVEL',
+			command_report: 'SENSOR_MULTILEVEL_REPORT',
+			command_report_parser: report => {
+				if (report['Sensor Type'] !== 'Temperature (version 1)') return null;
+				return report['Sensor Value (Parsed)'];
+			},
+		},
+		measure_luminance: {
+			command_class: 'COMMAND_CLASS_SENSOR_MULTILEVEL',
+			command_report: 'SENSOR_MULTILEVEL_REPORT',
+			command_report_parser: report => {
+				if (report['Sensor Type'] !== 'Luminance (version 1)') return null;
+				return report['Sensor Value (Parsed)'];
+			},
+		},
+		measure_battery: {
+			command_class: 'COMMAND_CLASS_BATTERY',
+			command_report: 'BATTERY_REPORT',
+			command_report_parser: report => {
+				if (report['Battery Level'] === "battery low warning") return 1;
+				if (report.hasOwnProperty('Battery Level (Raw)')) return report['Battery Level (Raw)'][0];
+				return null;
+			},
+		},
+	},
+	settings: {
+		basic_set_level: {
+			index: 2,
+			size: 1,
+		},
+		pir_sensitivity: {
+			index: 3,
+			size: 1,
+		},
+		light_threshold: {
+			index: 4,
+			size: 1,
+		},
+		operation_mode: {
+			index: 5,
+			size: 1,
+		},
+		multi_sensor_function_switch: {
+			index: 6,
+			size: 1,
+		},
+		pir_re_detect_interval_time: {
+			index: 8,
+			size: 1,
+		},
+		turn_off_light_time: {
+			index: 9,
+			size: 1,
+		},
+		auto_report_battery_time: {
+			index: 10,
+			size: 1,
+		},
+		auto_report_door_window_state_time: {
+			index: 11,
+			size: 1,
+		},
+		auto_report_illumination_time: {
+			index: 12,
+			size: 1,
+		},
+		auto_report_temperature_time: {
+			index: 13,
+			size: 1,
+		},
+		tamper_cancellation: (newValue, oldValue, deviceData) => {
+			if (tamperCancellation.hasOwnProperty(deviceData.token) && tamperCancellation[deviceData.token]) {
+				clearTimeout(tamperCancellation[deviceData.token]);
+				tamperCancellation[deviceData.token] = null;
+				const node = module.exports.nodes[deviceData.token];
+				if (node) {
+					if (node.state.alarm_tamper) module.exports.realtime(deviceData, 'alarm_tamper', false);
+					node.state.alarm_tamper = false;
+				}
+			}
+		},
+	},
+});


### PR DESCRIPTION
this pretty much reverts Commit cde6ce4e150e72c56fb4cb7f05778a5064b36960
from Feb 19 2017 for this driver which breaks it. (also version 0.0.14)
(he's been busy with this for a long time it seems like)

report parsers did not check what sensor type was coming in, now they do

report parsers of the contact and tamper alarms were from alarm sensor
command class, which is not supported, but also not used in the
"command_class" key.
changed it to the appropriate report parser.

removed get parsers in the temperature and luminance capabilities, they
are not used without a command_get, but also not very applicable for
battery devices

removed the battery get on awake, it is already reported every 6 hours
on default, changeable in the settings.

made the code more JS-Lint compliant

added tamper cancelation (this is not done by default), copy paste the
(tested) code from psp05